### PR TITLE
Support turning off truncated backpropagation. Other minor fixes.

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/advanced/modelling/charmodelling/melodl4j/MidiScoreIterationListener.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/advanced/modelling/charmodelling/melodl4j/MidiScoreIterationListener.java
@@ -1,0 +1,40 @@
+package org.deeplearning4j.examples.advanced.modelling.charmodelling.melodl4j;
+
+import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.optimize.api.BaseTrainingListener;
+
+import java.io.Serializable;
+import java.text.NumberFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class MidiScoreIterationListener extends BaseTrainingListener implements Serializable {
+    private int printIterations = 10;
+    private long lastTimeInMls = System.currentTimeMillis();
+    private int lastIteration = 0;
+
+    private static final NumberFormat numberFormat = NumberFormat.getNumberInstance();
+    static {
+        numberFormat.setMinimumFractionDigits(1);
+        numberFormat.setMaximumFractionDigits(1);
+    }
+    public MidiScoreIterationListener(int printIterations) {
+        this.printIterations = printIterations;
+    }
+
+    public MidiScoreIterationListener() {
+    }
+    public void iterationDone(Model model, int iteration, int epoch) {
+        if (this.printIterations <= 0) {
+            this.printIterations = 1;
+        }
+        if (iteration % this.printIterations == 0) {
+            double score = model.score();
+            long now = System.currentTimeMillis();
+            double seconds = 0.001*(now-lastTimeInMls)/(1+iteration-lastIteration);
+            System.out.println(numberFormat.format(seconds) + " seconds per iteration: score at iteration " +  iteration + " is " + score);
+            lastTimeInMls = now;
+            lastIteration = iteration;
+        }
+    }
+}


### PR DESCRIPTION
Support turning off truncated backpropagation. Print out configuration info to stdout and to composition output file (in comments). Use JFileChooser in PlayMelodyStrings. Improve documentation. Clean up code.

## What changes were proposed in this pull request?

Support turning off truncated backpropagation by setting tbpttLength=0.

Print out configuration information as a comment in the output composition file and to stdout. (This helps with benchmarking.)

Use JFileChooser in PlayMelodyStrings to choose the file to play melodies from. By default it uses the directory where MelodyModelingExample saves compositions.

Improve documentation. Clean up code.

## How was this patch tested?

I ran MelodyModelingExample several times, with tbpttLength=0 and tbpttLength>0.  I verified that composition files appear in the expected location.

Please review
https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
