### PR TITLE
Fix typo in method name that would cause compilation failure

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/advanced/modelling/charmodelling/melodl4j/TestMelodyConversion.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/advanced/modelling/charmodelling/melodl4j/TestMelodyConversion.java
@@ -80,7 +80,7 @@ public class TestMelodyConversion {
         }
         try {
             sanityCheck1();
-            File midiFile = MelodyModelingExample.makeSureFileIsInTmpDir(urlPath);
+            File midiFile = MelodyModelingExample.makeSureFileIsInTmpMidiDir(urlPath);
             testConversion(midiFile);
         } catch (Exception exc) {
             exc.printStackTrace();


### PR DESCRIPTION
## What changes were proposed in this pull request?

I'm sorry,  There was a three-character typo in a method name in TestMelodyConversion.java that causes a compilation exception.

## How was this patch tested?

Re-ran MelodyModelingExample and TestMelodyConverstion.

Please review
https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
